### PR TITLE
Add database entry for redland

### DIFF
--- a/sysreqs/redland.json
+++ b/sysreqs/redland.json
@@ -1,0 +1,10 @@
+{
+  "redland": {
+    "sysreqs": ["/redland/", "/librdf/"],
+   "platforms": {
+      "DEB": "librdf0-dev",
+      "OSX/brew": "redland",
+      "RPM": "redland-devel"
+    }
+  }
+}


### PR DESCRIPTION
I confirmed the package names on each of the three platforms. One questions remains: Does the `sysreqs` field I wrote match this?

> SystemRequirements: Mac OSX: redland (>= 1.0.14) ; Linux: librdf0 (>= 1.0.14),
    librdf0-dev (>= 1.0.14)

I saw a note in the docs for including a list of sysreqs, I hope I understood it correctly.